### PR TITLE
Check for context.object existing before accessing it

### DIFF
--- a/src/operators.py
+++ b/src/operators.py
@@ -39,7 +39,9 @@ class QUICKEXPORTER_OT_export_single(bpy.types.Operator):
 	def execute(self, context):
 		package = context.scene.quick_exporter.packages[self.index]
 		settings = package.settings
-		context_mode = context.object.mode
+
+		if context.object:
+			context_mode = context.object.mode
 
 		print()
 		print("Quick Exporter: Exporting Package " + str(self.index) + " (" + package.name + ")")
@@ -54,8 +56,9 @@ class QUICKEXPORTER_OT_export_single(bpy.types.Operator):
 		prev_active = context.active_object
 
 		# Deselect all objects
-		bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
-		bpy.ops.object.select_all(action='DESELECT')
+		if context.object:
+			bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
+			bpy.ops.object.select_all(action='DESELECT')
 		
 		for col in package.collections:
 			print("Quick Exporter:    + " + col.pointer.name + " (Collection)")
@@ -125,7 +128,8 @@ class QUICKEXPORTER_OT_export_single(bpy.types.Operator):
 			obj.select_set(True)
 
 		# Switch back to previous context mode
-		bpy.ops.object.mode_set(mode=context_mode, toggle=False)
+		if context.object:
+			bpy.ops.object.mode_set(mode=context_mode, toggle=False)
 
 		print("Quick Exporter: Exported to " + path)
 		return {'FINISHED'}


### PR DESCRIPTION
This should fix script crash when nothing is selected