### PR TITLE
Normalize the path separator to forward slashes

### DIFF
--- a/src/operators.py
+++ b/src/operators.py
@@ -70,7 +70,9 @@ class QUICKEXPORTER_OT_export_single(bpy.types.Operator):
 		path = bpy.path.abspath(package.path)
 		if not path.lower().endswith('.fbx'):
 			path = bpy.path.ensure_ext(bpy.path.abspath(package.path), package.name + '.fbx')
-			
+		
+		path = path.replace("\\", "/")
+
 		print(path)
 		
 		bpy.ops.export_scene.fbx(


### PR DESCRIPTION
This fixes an issue we ran into with artists on different OSes collaborating on the same .blend files:

- Artist 1 on Windows would save the path setting with backslashes
- Artist 2 on MacOS would open the .blend file and click Export
- This resulted in a .fbx file with a backslash in the actual filename

Things got really bad afterwards if Artist 2 didn't notice and proceeded to commit the backslash file in git. Git on Windows can't handle filenames with backslashes and this resulted in errors when trying to pull the repo on Windows.

This PR replaces all backslashes in the path string with forward slashes. This works great for MacOS assuming the backslash is never intended to be part of the filename. Windows can handle forward slashes as path separators as well.